### PR TITLE
Add dockerfile and image building workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,42 @@
+name: docker image
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  pull_request:
+
+env:
+  USER: genomicsoup
+  PACKAGE: simmr
+
+jobs:
+  build-image:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      
+      - name: login to ghcr
+        run: echo ${{ secrets.CR_TOKEN }} | docker login ghcr.io -u ${USER} --password-stdin
+
+      - name: Build image
+        run: |
+          export IMAGE=ghcr.io/${USER}/${PACKAGE}
+          export TAG=${{github.ref_name}}
+          export DOCKER_BUILDKIT=1
+          docker build \
+            -t ${IMAGE}:${GITHUB_SHA} \
+            -t ${IMAGE}:latest \
+            -t ${IMAGE}:${TAG/\//.} \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            .
+
+      - name: Push image
+        run: |
+          export IMAGE=ghcr.io/${USER}/${PACKAGE}
+          export TAG=${{github.ref_name}}
+          docker push ${IMAGE}:${GITHUB_SHA}
+          docker push ${IMAGE}:latest
+          docker push ${IMAGE}:${TAG/\//.}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# build environment
+FROM clux/muslrust:stable as builder
+
+WORKDIR /home/rust
+
+RUN cargo new --bin simmr
+
+WORKDIR /home/rust/simmr
+
+COPY simmr/ ./simmr
+COPY simmrd/ ./simmrd
+COPY shared/ ./shared
+COPY Cargo.toml ./
+
+RUN cargo build --release
+
+# release layer
+FROM alpine:latest
+
+COPY --from=builder /home/rust/simmr/target/x86_64-unknown-linux-musl/release/simmr /usr/local/bin/simmr
+#COPY --from=builder /home/rust/simmr/target/aarch64-unknown-linux-musl/release/simmr /usr/local/bin/simmr
+#COPY --from=builder /home/rust/simmr/target/x86_64-unknown-linux-musl/release/simmr /usr/local/bin/simmr
+
+CMD /bin/bash


### PR DESCRIPTION
This PR adds a Dockerfile for building `simmr` docker images and a workflow to build the image. Images are currently hosted on GHCR.